### PR TITLE
Add P2P rates microservice with click logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 # Docker
 *.log
 
+clicks.db
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@
 - **develop** – интеграция фич
 - **feature/*/** – для задач
 
+
+## P2P Rates Microservice
+See [p2p_rates_service](p2p_rates_service/README.md) for usage details.

--- a/p2p_rates_service/README.md
+++ b/p2p_rates_service/README.md
@@ -1,0 +1,24 @@
+# P2P Rates Microservice
+
+This microservice logs outgoing link clicks.
+
+## Running
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+Run the service:
+```bash
+uvicorn p2p_rates_service.main:app --reload
+```
+
+## Endpoints
+
+- `GET /click?target_url=<url>&user_id=<user>` – Logs the click and redirects to the target URL.
+- `GET /report` – Returns JSON statistics of clicks per user and URL.
+
+## Reporting Script
+
+Use `python -m p2p_rates_service.report` to print statistics from the database.

--- a/p2p_rates_service/database.py
+++ b/p2p_rates_service/database.py
@@ -1,0 +1,18 @@
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from datetime import datetime
+
+engine = create_engine('sqlite:///clicks.db', connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class Click(Base):
+    __tablename__ = 'clicks'
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(String, index=True)
+    target_url = Column(String)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/p2p_rates_service/main.py
+++ b/p2p_rates_service/main.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+from datetime import datetime
+
+from .database import SessionLocal, init_db, Click
+
+app = FastAPI()
+
+# Dependency to get DB session
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.on_event("startup")
+def startup():
+    init_db()
+
+@app.get("/click")
+def click(target_url: str, user_id: str, db: Session = Depends(get_db)):
+    if not target_url:
+        raise HTTPException(status_code=400, detail="target_url required")
+    click = Click(user_id=user_id, target_url=target_url, timestamp=datetime.utcnow())
+    db.add(click)
+    db.commit()
+    return RedirectResponse(url=target_url)
+
+@app.get("/report")
+def report(db: Session = Depends(get_db)):
+    result = db.query(Click.target_url, Click.user_id).all()
+    stats = {}
+    for url, user in result:
+        stats.setdefault(url, {})
+        stats[url][user] = stats[url].get(user, 0) + 1
+    return stats

--- a/p2p_rates_service/report.py
+++ b/p2p_rates_service/report.py
@@ -1,0 +1,19 @@
+from .database import SessionLocal, Click, init_db
+
+init_db()
+
+def print_stats():
+    db = SessionLocal()
+    result = db.query(Click.target_url, Click.user_id).all()
+    db.close()
+    stats = {}
+    for url, user in result:
+        stats.setdefault(url, {})
+        stats[url][user] = stats[url].get(user, 0) + 1
+    for url, users in stats.items():
+        print(f"URL: {url}")
+        for user, count in users.items():
+            print(f"  {user}: {count}")
+
+if __name__ == "__main__":
+    print_stats()

--- a/p2p_rates_service/requirements.txt
+++ b/p2p_rates_service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic


### PR DESCRIPTION
## Summary
- implement simple FastAPI service for tracking outgoing link clicks
- store click data in SQLite
- provide reporting endpoint and script
- document usage in README

## Testing
- `pip install -r p2p_rates_service/requirements.txt`
- `python -m p2p_rates_service.report`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480cfd4004832987e162e6f410ea39