### PR TITLE
Add telegram bot package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,22 @@
 - **develop** – интеграция фич
 - **feature/*/** – для задач
 
+## Телеграм-бот
+
+В каталоге `bot/` находится простой бот на базе `python-telegram-bot`. Для работы необходимы переменные окружения:
+
+```
+TELEGRAM_BOT_TOKEN   # токен бота
+COMMISSION_TEXT      # текст для /commission
+LOG_TEXT             # текст для /log
+LEADERBOARD_TEXT     # текст для /leaderboard
+FAQ_TEXT             # текст для /faq
+RATES_TEXT           # текст для /rates
+```
+
+Установите зависимости и запустите бота:
+
+```bash
+pip install -r requirements.txt
+python -m bot.main
+```

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+import os
+
+@dataclass
+class BotConfig:
+    token: str
+    commission_text: str
+    log_text: str
+    leaderboard_text: str
+    faq_text: str
+    rates_text: str
+
+    @classmethod
+    def from_env(cls) -> 'BotConfig':
+        return cls(
+            token=os.environ['TELEGRAM_BOT_TOKEN'],
+            commission_text=os.getenv('COMMISSION_TEXT', 'No commission info.'),
+            log_text=os.getenv('LOG_TEXT', 'No log info.'),
+            leaderboard_text=os.getenv('LEADERBOARD_TEXT', 'No leaderboard info.'),
+            faq_text=os.getenv('FAQ_TEXT', 'No FAQ info.'),
+            rates_text=os.getenv('RATES_TEXT', 'No rates info.'),
+        )

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -1,0 +1,21 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from .config import BotConfig
+
+config = BotConfig.from_env()
+
+async def commission(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(config.commission_text)
+
+async def log(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(config.log_text)
+
+async def leaderboard(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(config.leaderboard_text)
+
+async def faq(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(config.faq_text)
+
+async def rates(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(config.rates_text)

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,21 @@
+from telegram.ext import ApplicationBuilder, CommandHandler
+
+from .handlers import commission, log, leaderboard, faq, rates
+from .config import BotConfig
+
+
+def main() -> None:
+    config = BotConfig.from_env()
+    app = ApplicationBuilder().token(config.token).build()
+
+    app.add_handler(CommandHandler('commission', commission))
+    app.add_handler(CommandHandler('log', log))
+    app.add_handler(CommandHandler('leaderboard', leaderboard))
+    app.add_handler(CommandHandler('faq', faq))
+    app.add_handler(CommandHandler('rates', rates))
+
+    app.run_polling()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot>=20.0


### PR DESCRIPTION
## Summary
- add telegram bot package with simple handlers
- configure bot settings via environment variables
- document how to run the bot
- add dependency list

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68480abc618083298a8f7ed1deaad98d