### PR TITLE
Add searchable FAQ command

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -17,5 +17,5 @@ python -m bot
 The bot supports the following commands:
 - `/commission` – upload an XLSX report to calculate commissions
 - `/leaderboard`
-- `/faq`
+- `/faq` – ask a question about the service
 - `/rates`

--- a/bot/faq.py
+++ b/bot/faq.py
@@ -1,0 +1,35 @@
+"""FAQ utilities for the Telegram bot."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict, Optional
+
+_FAQ_DATA: List[Dict[str, str]] = []
+
+
+def _load_data() -> None:
+    """Load FAQ data from the JSON file."""
+    global _FAQ_DATA  # pylint: disable=global-statement
+    if _FAQ_DATA:
+        return
+    faq_path = Path(__file__).resolve().parents[1] / "data" / "faq.json"
+    with faq_path.open("r", encoding="utf-8") as f:
+        _FAQ_DATA = json.load(f)
+
+
+def find_answer(query: str) -> Optional[str]:
+    """Return the best matching answer for the query."""
+    _load_data()
+    query_tokens = set(query.lower().split())
+    best_answer = None
+    best_score = 0
+    for item in _FAQ_DATA:
+        question_tokens = set(item["question"].lower().split())
+        score = len(query_tokens & question_tokens)
+        if score > best_score:
+            best_score = score
+            best_answer = item["answer"]
+    if best_score == 0:
+        return None
+    return best_answer

--- a/bot/main.py
+++ b/bot/main.py
@@ -3,6 +3,7 @@ from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 
 from .commission import calculate_commissions
+from .faq import find_answer
 
 
 def get_token() -> str:
@@ -38,7 +39,16 @@ async def leaderboard(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
 async def faq(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle /faq command."""
-    await update.message.reply_text("Visit example.com/faq for answers to common questions.")
+    query = " ".join(context.args)
+    if not query:
+        await update.message.reply_text("Please provide a question after the command.")
+        return
+
+    answer = find_answer(query)
+    if answer:
+        await update.message.reply_text(answer)
+    else:
+        await update.message.reply_text("Sorry, I don't know the answer to that question.")
 
 
 async def rates(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/data/faq.json
+++ b/data/faq.json
@@ -1,0 +1,14 @@
+[
+  {
+    "question": "How do I reset my password?",
+    "answer": "Use the password reset form at example.com/reset to create a new password."
+  },
+  {
+    "question": "Where can I see my commissions?",
+    "answer": "Upload your XLSX report with /commission to receive a summary of commissions."
+  },
+  {
+    "question": "How do I contact support?",
+    "answer": "Send an email to support@example.com and we will respond shortly."
+  }
+]


### PR DESCRIPTION
## Summary
- store a simple FAQ in `data/faq.json`
- add `bot/faq.py` helper to load data and search for answers
- update `/faq` command to reply with search results
- clarify README description of the `/faq` command

## Testing
- `pip install -r bot/requirements.txt`
- `python - <<'PY'
from bot.faq import find_answer
print('Test1:', find_answer('reset password'))
print('Test2:', find_answer('how do i contact support'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68481bbf577083298bbac32ced591fd5