### PR TITLE
Add endpoints for latest P2P offers

### DIFF
--- a/p2p_rates_service/README.md
+++ b/p2p_rates_service/README.md
@@ -18,6 +18,8 @@ uvicorn p2p_rates_service.main:app --reload
 
 - `GET /click?target_url=<url>&user_id=<user>` – Logs the click and redirects to the target URL.
 - `GET /report` – Returns JSON statistics of clicks per user and URL.
+- `GET /offers/binance?ref=<code>` – Latest 5 Binance P2P offers with referral links.
+- `GET /offers/bybit?ref=<code>` – Latest 5 Bybit P2P offers with referral links.
 
 ## Reporting Script
 

--- a/p2p_rates_service/main.py
+++ b/p2p_rates_service/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.responses import RedirectResponse
+import httpx
 from sqlalchemy.orm import Session
 from datetime import datetime
 
@@ -37,3 +38,91 @@ def report(db: Session = Depends(get_db)):
         stats.setdefault(url, {})
         stats[url][user] = stats[url].get(user, 0) + 1
     return stats
+
+
+async def _get_json(client: httpx.AsyncClient, method: str, url: str, **kwargs):
+    response = await client.request(method, url, timeout=10, **kwargs)
+    response.raise_for_status()
+    return response.json()
+
+
+async def fetch_binance_offers(ref: str) -> list[dict]:
+    """Fetch 5 latest P2P offers from Binance."""
+    payload = {
+        "page": 1,
+        "rows": 5,
+        "payTypes": [],
+        "tradeType": "BUY",
+        "asset": "USDT",
+        "fiat": "RUB",
+    }
+    async with httpx.AsyncClient() as client:
+        data = await _get_json(
+            client,
+            "POST",
+            "https://p2p.binance.com/bapi/c2c/v2/friendly/c2c/adv/search",
+            json=payload,
+        )
+
+    offers = []
+    for item in data.get("data", [])[:5]:
+        adv = item.get("adv", {})
+        adv_no = adv.get("advNo")
+        url = f"https://p2p.binance.com/en/advertiserDetail?advertiserNo={adv_no}"
+        if ref:
+            url = f"{url}?ref={ref}"
+        offers.append({
+            "adv_no": adv_no,
+            "price": adv.get("price"),
+            "asset": adv.get("asset"),
+            "fiat": adv.get("fiatUnit"),
+            "trade_type": adv.get("tradeType"),
+            "url": url,
+        })
+    return offers
+
+
+async def fetch_bybit_offers(ref: str) -> list[dict]:
+    """Fetch 5 latest P2P offers from Bybit."""
+    params = {
+        "userId": 0,
+        "tokenId": "USDT",
+        "currencyId": "RUB",
+        "payment": "all",
+        "side": 1,
+        "size": 5,
+        "page": 1,
+    }
+    async with httpx.AsyncClient() as client:
+        data = await _get_json(
+            client,
+            "GET",
+            "https://api2.bybit.com/fiat/otc/v2/public/ad/list",
+            params=params,
+        )
+
+    offers = []
+    for item in data.get("result", {}).get("items", [])[:5]:
+        adv_id = item.get("id")
+        url = f"https://www.bybit.com/fiat/trade/otc/detail?id={adv_id}"
+        if ref:
+            url = f"{url}?ref={ref}"
+        offers.append({
+            "adv_id": adv_id,
+            "price": item.get("price"),
+            "asset": item.get("tokenId"),
+            "fiat": item.get("currencyId"),
+            "trade_type": "BUY" if item.get("side") == 1 else "SELL",
+            "url": url,
+        })
+    return offers
+
+
+@app.get("/offers/binance")
+async def binance_offers(ref: str = ""):
+    return await fetch_binance_offers(ref)
+
+
+@app.get("/offers/bybit")
+async def bybit_offers(ref: str = ""):
+    return await fetch_bybit_offers(ref)

--- a/p2p_rates_service/requirements.txt
+++ b/p2p_rates_service/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 sqlalchemy
 pydantic
+httpx


### PR DESCRIPTION
## Summary
- support HTTP requests with httpx
- add `/offers/binance` and `/offers/bybit` to return latest P2P offers with referral code support
- document new endpoints in the microservice README
- add `httpx` dependency

## Testing
- `python -m py_compile p2p_rates_service/main.py`
- `python -m py_compile bot/main.py`
- `pip install -q -r p2p_rates_service/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68481d16a7cc8329aeb807bbbeff72c8