### PR TITLE
Add pytest tests and quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,25 @@ See [p2p_rates_service](p2p_rates_service/README.md) for usage details.
 
 ## Telegram Bot
 See [bot](bot/README.md) for usage details.
+
+## Quick start
+
+Install dependencies for both the service and the bot:
+
+```bash
+pip install -r p2p_rates_service/requirements.txt
+pip install -r bot/requirements.txt
+```
+
+Set required environment variables and run the applications.
+Only the Telegram bot needs a token:
+
+```bash
+export TELEGRAM_BOT_TOKEN=<your bot token>
+
+# run the microservice
+uvicorn p2p_rates_service.main:app --reload
+
+# in another terminal run the bot
+python -m bot
+```

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from p2p_rates_service import database, main
+
+
+@pytest.fixture
+def client():
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    database.engine = engine
+    database.SessionLocal = TestingSessionLocal
+    database.Base.metadata.create_all(bind=engine)
+
+    main.SessionLocal = TestingSessionLocal
+    main.init_db = lambda: None
+
+    with TestClient(main.app) as c:
+        yield c
+
+    os.remove(db_path)
+
+
+def test_click_and_report(client):
+    response = client.get("/click", params={"target_url": "https://example.com", "user_id": "user"}, follow_redirects=False)
+    assert response.status_code == 307
+
+    report = client.get("/report")
+    assert report.status_code == 200
+    assert report.json() == {"https://example.com": {"user": 1}}
+
+
+def test_click_requires_target_url(client):
+    response = client.get("/click", params={"user_id": "foo"})
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add pytest-based tests for microservice endpoints
- document how to run the services and set the bot token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481e2ede3c832985ad4d1f172d6b23