### PR TITLE
Add README token comment

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -7,6 +7,8 @@ from .faq import find_answer
 
 
 def get_token() -> str:
+    # TELEGRAM_BOT_TOKEN should come from the environment or a `.env` file.
+    # See the README for setup instructions.
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     if not token:
         raise RuntimeError("TELEGRAM_BOT_TOKEN env var is required")


### PR DESCRIPTION
## Summary
- document that TELEGRAM_BOT_TOKEN must come from env or `.env` in `bot/main.py`

## Testing
- `pip install -r p2p_rates_service/requirements.txt`
- `pip install -r bot/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684822569984832985b98e15aee95cbb