### PR TITLE
Enhance commission calculator

### DIFF
--- a/bot/commission.py
+++ b/bot/commission.py
@@ -8,9 +8,44 @@ from typing import Dict
 import pandas as pd
 
 # Country specific commission percentages
+# Values represent the commission taken from deposits for each country.
 COUNTRY_RATES: Dict[str, float] = {
-    "Kazakhstan": 0.05,
-    "Russia": 0.07,
+    "Algeria": 0.05,
+    "Argentina": 0.05,
+    "Azerbaijan": 0.06,
+    "Bangladesh": 0.05,
+    "Benin": 0.05,
+    "Bolivia": 0.08,
+    "Brazil": 0.05,
+    "Burkina Faso": 0.05,
+    "Cameroon": 0.05,
+    "Colombia": 0.05,
+    "Congo (Kinshasa)": 0.05,
+    "Cote D'Ivoire": 0.05,
+    "Djibouti": 0.05,
+    "Ecuador": 0.05,
+    "Egypt": 0.05,
+    "Gabon": 0.05,
+    "Guinea": 0.05,
+    "Haiti": 0.05,
+    "India": 0.05,
+    "Iran": 0.05,
+    "Kyrgyzstan": 0.08,
+    "Madagascar": 0.05,
+    "Morocco": 0.05,
+    "Nepal": 0.05,
+    "Niger": 0.05,
+    "Pakistan": 0.05,
+    "Somalia": 0.05,
+    "Sri Lanka": 0.05,
+    "Togo": 0.05,
+    "Tunisia": 0.05,
+    "Turkey": 0.08,
+    "Turkmenistan": 0.08,
+    "Uzbekistan": 0.08,
+    "Venezuela": 0.05,
+    "Zambia": 0.05,
+    "Paraguay": 0.08,
 }
 # Default percentage if country is not found in COUNTRY_RATES
 DEFAULT_RATE = 0.05
@@ -19,27 +54,49 @@ def calculate_commissions(file_bytes: bytes) -> str:
     """Parse XLSX file bytes and return formatted commission report."""
     df = pd.read_excel(BytesIO(file_bytes))
 
-    required = {"Operation", "Country", "Date", "Amount"}
+    required = {
+        "Date",
+        "Operation",
+        "Country",
+        "Currency",
+        "Received",
+        "Paid out",
+        "Payout Sum",
+    }
     missing = required - set(df.columns)
     if missing:
-        raise ValueError(f"Missing columns: {', '.join(missing)}")
+        raise ValueError(f"Missing columns: {', '.join(sorted(missing))}")
 
-    df = df[df["Operation"] == "W1=W2"].copy()
+    # Ignore rows with non-zero cancellation amounts
+    df = df[df["Payout Sum"] == 0].copy()
     if df.empty:
-        return "No operations matching W1=W2"
+        return "No valid operations found"
 
     df["Date"] = pd.to_datetime(df["Date"])
     df["Month"] = df["Date"].dt.to_period("M")
-    df["Rate"] = df["Country"].map(COUNTRY_RATES).fillna(DEFAULT_RATE)
-    df["Commission"] = df["Amount"] * df["Rate"]
 
-    grouped = df.groupby("Month")["Commission"].sum().reset_index()
+    deposits = df[df["Operation"] == "W1"].copy()
+    deposits["Rate"] = deposits["Country"].map(COUNTRY_RATES).fillna(DEFAULT_RATE)
+    deposits["Commission"] = deposits["Received"] * deposits["Rate"]
+
+    withdrawals = df[df["Operation"] == "W2"].copy()
+    withdrawals["Commission"] = withdrawals["Paid out"] * 0.02
+
+    grouped = (
+        pd.concat(
+            [deposits[["Month", "Commission"]], withdrawals[["Month", "Commission"]]],
+            ignore_index=True,
+        )
+        .groupby("Month")["Commission"]
+        .sum()
+        .sort_index()
+    )
 
     lines = []
     total = 0.0
-    for _, row in grouped.iterrows():
-        month_str = row["Month"].strftime("%Y-%m")
-        value = float(row["Commission"])
+    for month, value in grouped.items():
+        month_str = month.strftime("%Y-%m")
+        value = float(value)
         total += value
         lines.append(f"{month_str}: {value:.2f}")
     lines.append(f"Total: {total:.2f}")

--- a/tests/test_commission.py
+++ b/tests/test_commission.py
@@ -1,0 +1,54 @@
+import pandas as pd
+from io import BytesIO
+from bot.commission import calculate_commissions
+
+
+def _to_bytes(df: pd.DataFrame) -> bytes:
+    buf = BytesIO()
+    df.to_excel(buf, index=False)
+    return buf.getvalue()
+
+
+def test_calculate_commissions():
+    data = {
+        "Date": [
+            "2023-01-15",
+            "2023-01-20",
+            "2023-02-10",
+            "2023-02-15",
+            "2023-02-16",
+            "2023-03-01",
+        ],
+        "Operation": ["W1", "W2", "W1", "W2", "W1", "W1"],
+        "Country": [
+            "Brazil",
+            "Brazil",
+            "Bolivia",
+            "Bolivia",
+            "Bolivia",
+            "Paraguay",
+        ],
+        "Currency": ["BRL", "BRL", "BOB", "BOB", "BOB", "PYG"],
+        "Received": [100, 0, 50, 0, 100, 200],
+        "Paid out": [0, 200, 0, 100, 0, 0],
+        "Payout Sum": [0, 0, 0, 0, 5, 0],
+    }
+    df = pd.DataFrame(data)
+    result = calculate_commissions(_to_bytes(df))
+    expected = "\n".join([
+        "2023-01: 9.00",
+        "2023-02: 6.00",
+        "2023-03: 16.00",
+        "Total: 31.00",
+    ])
+    assert result == expected
+
+
+def test_missing_columns():
+    df = pd.DataFrame({"Date": ["2023-01-01"]})
+    try:
+        calculate_commissions(_to_bytes(df))
+    except ValueError as exc:
+        assert "Missing columns" in str(exc)
+    else:
+        assert False, "ValueError not raised"


### PR DESCRIPTION
## Summary
- handle monthly commissions based on deposit/withdrawal operations
- expand error checking in commission parser
- list deposit commission rates for many countries
- add tests for commission calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848209a318c8329b6a024123e05649f